### PR TITLE
declarations across multiple lines

### DIFF
--- a/src/compiler/lexer/Lexer.py
+++ b/src/compiler/lexer/Lexer.py
@@ -11,7 +11,8 @@ symbols = {
     ']': TL.RBRACK,
     ',': TL.COMMA,
     '.': TL.PERIOD,
-    ':': TL.COLON
+    ':': TL.COLON,
+    ';': TL.SEMICOLON
 }
 
 # --- Types, effects, and keywords used in our language --- #

--- a/src/compiler/lexer/Token.py
+++ b/src/compiler/lexer/Token.py
@@ -26,6 +26,7 @@ class TokenLabel(Enum):
     NUM = 23
     FUNC = 24
     CAPTION=25
+    SEMICOLON=26
 
 class Token():
     def __init__(self, key, value, start=-1, end=-1):

--- a/src/compiler/parser/DeclarationParser.py
+++ b/src/compiler/parser/DeclarationParser.py
@@ -1,3 +1,4 @@
+
 from src.compiler.lexer.Token import Token, TokenLabel
 from src.compiler.lexer.Token import TokenLabel as TL
 from src.compiler.VideoVariable import Clip, VideoVariable
@@ -14,10 +15,35 @@ class DeclarationParser():
         self.functions: dict = {} # Holds all declared functions from end user and acts as a look-up table
         self.line_number : int = 1
 
+    def join_lines(self, lines_of_tokens: list[list[Token]]) -> list[list[Token]]:
+        """
+        Merges multi-line declarations into single token lists by treating
+        SEMICOLON as the statement terminator rather than newlines.
+        """
+        statements = []
+        current_statement = []
+
+        for line in lines_of_tokens:
+            for token in line:
+                match token.key:
+                    case TL.END_OF_LINE:
+                        continue
+                    case TL.SEMICOLON:
+                        if current_statement:
+                            statements.append(current_statement)
+                            current_statement = []
+                    case _:
+                        current_statement.append(token)
+
+        if current_statement:
+            statements.append(current_statement)
+        return statements
+
     def parse_source(self, lines_of_tokens : list[list[Token]]):
         """
         Takes in a list of lists of tokens and returns the dict of states.
         """
+        lines_of_tokens = self.join_lines(lines_of_tokens)
         for tokens in lines_of_tokens:
             if len(tokens) == 0:
                 continue
@@ -37,6 +63,8 @@ class DeclarationParser():
                     self.primitives.update({tokens[1].value : self.__parse_primitive_number(tokens)})
                 case TL.FUNC:
                     self.functions[tokens[1].value] = self.__parse_func_decl(tokens)
+                case TL.FUNC_COMP:
+                    raise Exception(f"Line {self.line_number}: Unexpected '|>' - did you put a semicolon too early?")
             self.line_number += 1
 
 

--- a/tests/parser/ParserTest.py
+++ b/tests/parser/ParserTest.py
@@ -11,8 +11,8 @@ NOTE FOR BRIAN: Used AI to generate these test cases, did not want to do this by
 """
 
 TEST1 = """
-num n1 = 5.0
-video intro = "intro.mp4" (0,e) |> saturation(n1) |> speed(1.5)
+num n1 = 5.0;
+video intro = "intro.mp4" (0,e) |> saturation(n1) |> speed(1.5);
 timeline
 intro 0 1
 render "lets_play.mp4" [1920,1080]
@@ -38,9 +38,9 @@ expected_primitives1 = {"n1": '5.0'}
 
 
 TEST2 = """
-func f(a,b,c) = saturation(a) |> speed(b) |> volume(c)
-video v1 = "v1.mp4" (0,e) |> f(1,2,3)
-video v2 = "v2.mp4" (0,e) |> f(3,1,2)
+func f(a,b,c) = saturation(a) |> speed(b) |> volume(c);
+video v1 = "v1.mp4" (0,e) |> f(1,2,3);
+video v2 = "v2.mp4" (0,e) |> f(3,1,2);
 timeline
 v1 0 1
 v2 0 2


### PR DESCRIPTION
added semi-colons to token and lexer so when a video is run, a semi-colon needs to be at the end of each video and sound effect statement so the program knows when the line ends. there is an error that will be thrown in the UI terminal if a semicolon is added to early or multiple times in a multi line delcatation.
closes #57 